### PR TITLE
fixes deploy problem

### DIFF
--- a/generators/app/templates/bin/deploy
+++ b/generators/app/templates/bin/deploy
@@ -6,7 +6,7 @@ import lambda from 'node-aws-lambda';
 import nomnom from 'nomnom';
 
 const exists = (filename) => fs.existsSync(filename) ? undefined : `${filename} does not exist`;
-const requireFile = filename => require(path.join(process.cwd(), filename));
+const requireFile = (filename) => require(path.join(process.cwd(), filename));
 
 const { config, zip } = nomnom
                           .script('deploy')

--- a/generators/app/templates/bin/deploy
+++ b/generators/app/templates/bin/deploy
@@ -6,11 +6,11 @@ import lambda from 'node-aws-lambda';
 import nomnom from 'nomnom';
 
 const exists = (filename) => fs.existsSync(filename) ? undefined : `${filename} does not exist`;
-const requireFile = (transform = i => i) => (filename) => transform(require(path.join(process.cwd(), filename)));
+const requireFile = filename => require(path.join(process.cwd(), filename));
 
 const { config, zip } = nomnom
                           .script('deploy')
-                          .option('config', { required: true, callback: exists, transform: requireFile(_ => _.default) })
+                          .option('config', { required: true, callback: exists, transform: requireFile })
                           .option('zip', { full: 'package', abbr: 'p', required: true, callback: exists })
                           .parse();
 


### PR DESCRIPTION
the nomnom transform was acting strangely; the result was that the "config" option would get lost:

```
> $ bin/deploy --config config/lambda.config.js --package build/package.zip

config argument is required

Usage: deploy [options]

Options:
   --config
   -p, --package
```

This PR retains the "config" option, and I can deploy with it.